### PR TITLE
Menu implementation for Cocoa/macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -681,7 +681,6 @@ krkrsdl2_dependson = [
 
 if target_machine.system() == 'darwin'
 	cocoa = dependency('appleframeworks', modules: 'Cocoa')
-	add_languages('objcpp')
 	krkrsdl2_dependson += cocoa
 	krkrsdl2_src += 'src/plugins/menu/cocoa.mm'
 endif

--- a/meson.build
+++ b/meson.build
@@ -448,6 +448,11 @@ krkrsdl2_src = [
 	'src/core/visual/sdl2/TVPScreen.cpp',
 	'src/core/visual/sdl2/VideoOvlImpl.cpp',
 	'src/core/visual/sdl2/WindowImpl.cpp',
+	'src/plugins/kremscripten.cpp',
+	'src/plugins/scripts.cc',
+	# menu extension
+	'src/plugins/menu/menu.cc',
+	'src/plugins/menu/win32.cc',
 ]
 krkrsdl2_includes = [
 	'src/core/base/sdl2',
@@ -669,6 +674,14 @@ endif
 krkrsdl2_dependson = [
 	sdl2_dep,
 ]
+
+if target_machine.system() == 'darwin'
+	cocoa = dependency('appleframeworks', modules: 'Cocoa')
+	add_languages('objcpp')
+	krkrsdl2_dependson += cocoa
+	krkrsdl2_src += 'src/plugins/menu/cocoa.mm'
+endif
+
 krkrsdl2_override_options = []
 if target_machine.system() == 'emscripten'
 	krkrsdl2_override_options += [

--- a/src/plugins/menu/cocoa.mm
+++ b/src/plugins/menu/cocoa.mm
@@ -31,17 +31,13 @@ class _NativeMenuItem_Impl {
 public:
   _NativeMenuItem_Impl(NativeMenuItem *interface, std::string caption = "")
       : m_refCount(1), m_interface(interface), m_menu(nullptr), m_item(nullptr),
-        m_parent(nullptr), m_children(), m_caption(caption), m_modifier(""),
+        m_parent(nullptr), m_children(), m_caption(caption), m_key(""),
         m_checked(false), m_enabled(true), m_visible(true), m_radio(false),
         m_activated(false), m_radioGroup(true), m_delegate(nullptr) {
     // create an empty menu stub
   }
 
   virtual ~_NativeMenuItem_Impl() {
-    if (m_activated) {
-      NSLog(@"activated menu released");
-    }
-
     for (auto &v : m_children) {
       v->m_parent = nullptr;
       v->release();
@@ -74,10 +70,6 @@ public:
     item->m_parent = this;
     m_children.push_back(item);
 
-    if (m_activated) {
-      NSLog(@"activated menu item added: %s", item->m_caption.c_str());
-    }
-
     [m_menu addItem:item->m_item];
   }
 
@@ -92,11 +84,6 @@ public:
 
     item->m_parent = this;
     m_children.insert(m_children.begin() + at, item);
-
-    if (m_activated) {
-      NSLog(@"activated menu item inserted: %s, at: %d",
-            item->m_caption.c_str(), at);
-    }
 
     [m_menu insertItem:item->m_item atIndex:static_cast<NSInteger>(at)];
   }
@@ -215,13 +202,14 @@ public:
 
   bool getChecked() const { return m_checked; }
 
-  void setKeyModifier(std::string const &modifier) {
-    m_modifier = modifier;
+  void setKeyEquivalent(std::string const &key) {
+    m_key = key;
 
-    // TODO: implement key modifier setter
+    // TODO: implement key setter
+    NSLog(@"key received: %s", m_key.c_str());
   }
 
-  std::string const &getKeyModifier() const { return m_modifier; }
+  std::string const &getKeyEquivalent() const { return m_key; }
 
   _NativeMenuItem_Impl const *getRoot() const {
     if (m_parent)
@@ -311,7 +299,7 @@ private:
   _NativeMenuItem_Impl *              m_parent;
   std::vector<_NativeMenuItem_Impl *> m_children;
   std::string                         m_caption;
-  std::string                         m_modifier;
+  std::string                         m_key;
   bool                                m_checked;
   bool                                m_enabled;
   bool                                m_visible;
@@ -416,12 +404,12 @@ void NativeMenuItem::setChecked(bool flag) { m_impl->setChecked(flag); }
 
 bool NativeMenuItem::getChecked() const { return m_impl->getChecked(); }
 
-void NativeMenuItem::setKeyModifier(std::string const &modifier) {
-  return m_impl->setKeyModifier(modifier);
+void NativeMenuItem::setKeyEquivalent(std::string const &key) {
+  return m_impl->setKeyEquivalent(key);
 }
 
-std::string const &NativeMenuItem::getKeyModifier() {
-  return m_impl->getKeyModifier();
+std::string const &NativeMenuItem::getKeyEquivalent() {
+  return m_impl->getKeyEquivalent();
 }
 
 void NativeMenuItem::setEnabled(bool flag) { m_impl->setEnabled(flag); }

--- a/src/plugins/menu/cocoa.mm
+++ b/src/plugins/menu/cocoa.mm
@@ -1,0 +1,468 @@
+/**
+ * @file     cocoa.mm
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    menu.dll implementation for macOS.
+ * @version  0.1
+ * @date     2020-08-09
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ *
+ */
+
+#ifdef __APPLE__
+
+#include <Cocoa/Cocoa.h>
+#include <string>
+#include <vector>
+
+#include <assert.h>
+
+#include "common.h"
+
+@interface KrkrMenuItem : NSMenuItem {
+  _NativeMenuItem_Impl *m_menuItem;
+}
+- (id)initWithMenuItemImpl:(_NativeMenuItem_Impl *)menuItem;
+- (IBAction)handleClick:(id)sender;
+
+@end
+
+class _NativeMenuItem_Impl {
+public:
+  _NativeMenuItem_Impl(NativeMenuItem *interface, std::string caption = "")
+      : m_refCount(1), m_interface(interface), m_menu(nullptr), m_item(nullptr),
+        m_parent(nullptr), m_children(), m_caption(caption), m_modifier(""),
+        m_checked(false), m_enabled(true), m_visible(true), m_radio(false),
+        m_radioGroup(true), m_delegate(nullptr), m_activated(false) {
+    // create an empty menu stub
+  }
+
+  virtual ~_NativeMenuItem_Impl() {
+    if (m_activated) {
+      NSLog(@"activated menu released");
+    }
+
+    for (auto &v : m_children) {
+      v->m_parent = nullptr;
+      v->release();
+    }
+
+    if (m_menu) {
+      [m_menu release];
+    }
+
+    if (m_item) {
+      [m_item release];
+    }
+  }
+
+  void activate() {
+    ensureMenu();
+    m_activated = true;
+    [NSApp setMainMenu:m_menu];
+  }
+
+  void addItem(_NativeMenuItem_Impl *item) {
+    item->retain();
+
+    if (item->m_parent)
+      item->m_parent->remove(item);
+
+    item->ensureMenuItem();
+    this->ensureMenu();
+
+    item->m_parent = this;
+    m_children.push_back(item);
+
+    if (m_activated) {
+      NSLog(@"activated menu item added: %s", item->m_caption.c_str());
+    }
+
+    [m_menu addItem:item->m_item];
+  }
+
+  void insert(_NativeMenuItem_Impl *item, int at) {
+    item->retain();
+
+    if (item->m_parent)
+      item->m_parent->remove(item);
+
+    item->ensureMenuItem();
+    this->ensureMenu();
+
+    item->m_parent = this;
+    m_children.insert(m_children.begin() + at, item);
+
+    if (m_activated) {
+      NSLog(@"activated menu item inserted: %s, at: %d",
+            item->m_caption.c_str(), at);
+    }
+
+    [m_menu insertItem:item->m_item atIndex:static_cast<NSInteger>(at)];
+  }
+
+  void retain() { m_refCount++; }
+
+  bool release(bool respectIntf = true) {
+    if (respectIntf) {
+      return m_interface->release();
+    }
+
+    if (--m_refCount == 0) {
+      assert("there should be no parent" && !m_parent);
+      delete this;
+      return true;
+    }
+
+    return false;
+  }
+
+  void popup(int flags, int x, int y) {
+    if (!m_menu)
+      return;
+
+    [m_menu popUpMenuPositioningItem:m_item
+                          atLocation:NSMakePoint(x, y)
+                              inView:nil];
+  }
+
+  void remove(_NativeMenuItem_Impl *item) {
+    if (!item || item->m_parent != this) {
+      return;
+    }
+
+    auto p = std::find(m_children.begin(), m_children.end(), item);
+
+    if (p != m_children.end()) {
+      m_children.erase(p);
+
+      item->m_parent = nullptr;
+      item->release();
+
+      [m_menu removeItem:item->m_item];
+    }
+  }
+
+  void *getMenuRef() const { return reinterpret_cast<void *>(m_menu); }
+
+  void *getMenuItemRef() const { return reinterpret_cast<void *>(m_item); }
+
+  void setCaption(std::string const &caption) {
+    // separator
+    if (m_caption != "-" && caption == "-") {
+      auto at   = getIndex();
+      m_item    = [NSMenuItem separatorItem];
+      m_caption = caption;
+      if (m_parent) {
+        [(m_parent->m_menu) remove:m_item];
+        [(m_parent->m_menu) insertItem:m_item
+                               atIndex:static_cast<NSInteger>(at)];
+      }
+      return;
+    } else if (m_caption == "-" && caption != "-") {
+      auto at   = getIndex();
+      m_item    = nil;
+      m_caption = caption;
+      ensureMenuItem();
+      if (m_parent) {
+        [(m_parent->m_menu) remove:m_item];
+        [(m_parent->m_menu) insertItem:m_item
+                               atIndex:static_cast<NSInteger>(at)];
+      }
+      return;
+    }
+
+    m_caption = caption;
+
+    auto sanitizedCaption = m_caption;
+
+    sanitizedCaption.erase(
+        std::remove(sanitizedCaption.begin(), sanitizedCaption.end(), '&'),
+        sanitizedCaption.end());
+
+    auto theCaption = [NSString stringWithUTF8String:sanitizedCaption.c_str()];
+
+    if (m_menu) {
+      [m_menu setTitle:theCaption];
+    }
+    if (m_item) {
+      [m_item setTitle:theCaption];
+    }
+  }
+
+  std::string const &getCaption() const { return m_caption; }
+
+  void setChecked(bool flag) {
+    m_checked = flag;
+
+    if (!m_item)
+      return;
+
+    [m_item
+        setState:m_checked ? NSControlStateValueOn : NSControlStateValueOff];
+
+    // if the item is a radio button, uncheck other elements in the group.
+    if (m_radio && flag) {
+      for (auto &i : m_parent->m_children) {
+        if (i == this || i->m_radioGroup != this->m_radioGroup) {
+          continue;
+        }
+
+        i->setChecked(false);
+      }
+    }
+  }
+
+  bool getChecked() const { return m_checked; }
+
+  void setKeyModifier(std::string const &modifier) {
+    m_modifier = modifier;
+
+    // TODO: implement key modifier setter
+  }
+
+  std::string const &getKeyModifier() const { return m_modifier; }
+
+  _NativeMenuItem_Impl const *getRoot() const {
+    if (m_parent)
+      return m_parent->getRoot();
+
+    return this;
+  }
+
+  _NativeMenuItem_Impl *getRoot() {
+    if (m_parent)
+      return m_parent->getRoot();
+
+    return this;
+  }
+
+  _NativeMenuItem_Impl const *getParent() const { return this->m_parent; }
+
+  _NativeMenuItem_Impl *getParent() { return this->m_parent; }
+
+  std::vector<_NativeMenuItem_Impl *> const &getChildren() const {
+    return this->m_children;
+  }
+
+  void setEnabled(bool flag) {
+    m_enabled = flag;
+
+    if (!m_item)
+      return;
+
+    [m_item setEnabled:m_enabled];
+  }
+
+  bool getEnabled() const { return m_enabled; }
+
+  void setVisible(bool flag) {
+    m_visible = flag;
+
+    if (!m_item)
+      return;
+
+    [m_item setHidden:!m_visible];
+  }
+
+  bool getVisible() const { return m_visible; }
+
+  int getIndex() const {
+    if (!m_parent)
+      return -1;
+
+    auto const &siblings = m_parent->m_children;
+    auto        p        = std::find(siblings.begin(), siblings.end(), this);
+
+    if (p == siblings.end()) {
+      return -1;
+    }
+
+    return std::distance(siblings.begin(), p);
+  }
+
+  void setIndex(int index) {
+    if (m_parent)
+      m_parent->insert(this, index);
+  }
+
+  void setRadio(bool flag) { m_radio = flag; }
+
+  bool getRadio() const { return m_radio; }
+
+  void setGroup(int group) { m_radioGroup = group; }
+
+  int getGroup() const { return m_radioGroup; }
+
+  void handleClick() {
+    if (m_delegate)
+      m_delegate->handleClick(this->m_interface);
+  }
+
+  NativeMenuItem *getIntf() const { return m_interface; }
+
+  void setDelegate(INativeMenuItemDelegate *delegate) { m_delegate = delegate; }
+
+private:
+  size_t                              m_refCount;
+  NativeMenuItem *                    m_interface;
+  NSMenu *                            m_menu;
+  KrkrMenuItem *                      m_item;
+  _NativeMenuItem_Impl *              m_parent;
+  std::vector<_NativeMenuItem_Impl *> m_children;
+  std::string                         m_caption;
+  std::string                         m_modifier;
+  bool                                m_checked;
+  bool                                m_enabled;
+  bool                                m_visible;
+  bool                                m_radio;
+  bool                                m_activated;
+  int                                 m_radioGroup;
+  INativeMenuItemDelegate *           m_delegate;
+
+  void ensureMenuItem() {
+    if (!m_item) {
+      m_item = [[KrkrMenuItem alloc] initWithMenuItemImpl:this];
+    }
+
+    setCaption(m_caption);
+
+    if (m_menu) {
+      [m_item setSubmenu:m_menu];
+    }
+  }
+
+  void ensureMenu() {
+    if (!m_menu) {
+      m_menu = [[NSMenu alloc] init];
+    }
+
+    setCaption(m_caption);
+
+    if (m_item) {
+      [m_item setSubmenu:m_menu];
+    }
+  }
+};
+
+/* クラスの実装部 */
+@implementation KrkrMenuItem : NSMenuItem
+- (id)initWithMenuItemImpl:(_NativeMenuItem_Impl *)menuItem {
+  if (self = [super init]) {
+    m_menuItem = menuItem;
+    [self setTarget:self];
+    [self setAction:@selector(handleClick:)];
+  }
+
+  return self;
+}
+
+- (IBAction)handleClick:(id)sender {
+  m_menuItem->handleClick();
+}
+
+@end
+
+NativeMenuItem::NativeMenuItem(std::string caption, void *_nativeWindow) {
+  m_impl = new _NativeMenuItem_Impl(this, caption);
+  m_impl->retain();
+}
+
+NativeMenuItem::~NativeMenuItem() {
+  if (m_impl)
+    m_impl->release();
+}
+
+void NativeMenuItem::activate() { m_impl->activate(); }
+
+void NativeMenuItem::addItem(NativeMenuItem *item) {
+  m_impl->addItem(item->m_impl);
+}
+
+void NativeMenuItem::insert(NativeMenuItem *item, int at) {
+  m_impl->insert(item->m_impl, at);
+}
+
+void NativeMenuItem::retain() { m_impl->retain(); }
+
+bool NativeMenuItem::release() {
+  if (!m_impl) {
+    return true;
+  }
+
+  bool res = m_impl->release(false);
+  if (m_impl && res) {
+    m_impl = nullptr;
+    delete this;
+  }
+  return res;
+}
+
+void NativeMenuItem::popup(int flags, int x, int y) {
+  m_impl->popup(flags, x, y);
+}
+
+void NativeMenuItem::remove(NativeMenuItem *item) {
+  m_impl->remove(item->m_impl);
+}
+
+void NativeMenuItem::setCaption(std::string const &caption) {
+  m_impl->setCaption(caption);
+}
+
+std::string const &NativeMenuItem::getCaption() { return m_impl->getCaption(); }
+
+void NativeMenuItem::setChecked(bool flag) { m_impl->setChecked(flag); }
+
+bool NativeMenuItem::getChecked() const { return m_impl->getChecked(); }
+
+void NativeMenuItem::setKeyModifier(std::string const &modifier) {
+  return m_impl->setKeyModifier(modifier);
+}
+
+std::string const &NativeMenuItem::getKeyModifier() {
+  return m_impl->getKeyModifier();
+}
+
+void NativeMenuItem::setEnabled(bool flag) { m_impl->setEnabled(flag); }
+
+bool NativeMenuItem::getEnabled() const { return m_impl->getEnabled(); }
+
+void NativeMenuItem::setVisible(bool flag) { m_impl->setVisible(flag); }
+
+bool NativeMenuItem::getVisible() const { return m_impl->getVisible(); }
+
+void NativeMenuItem::setRadio(bool flag) { m_impl->setRadio(flag); }
+
+bool NativeMenuItem::getRadio() const { return m_impl->getRadio(); }
+
+void NativeMenuItem::setIndex(int index) { m_impl->setIndex(index); }
+
+int NativeMenuItem::getIndex() const { return m_impl->getIndex(); }
+
+void NativeMenuItem::setGroup(int group) { m_impl->setGroup(group); }
+
+int NativeMenuItem::getGroup() const { return m_impl->getGroup(); }
+
+NativeMenuItem *NativeMenuItem::getRoot() {
+  return m_impl->getRoot()->getIntf();
+}
+
+NativeMenuItem *NativeMenuItem::getParent() {
+  return m_impl->getParent()->getIntf();
+}
+
+std::vector<NativeMenuItem *> NativeMenuItem::getChildren() {
+  std::vector<NativeMenuItem *> vec;
+  auto const &                  children = m_impl->getChildren();
+  for (auto &c : children) {
+    vec.push_back(c->getIntf());
+  }
+  return vec;
+}
+
+void NativeMenuItem::setDelegate(INativeMenuItemDelegate *delegate) {
+  m_impl->setDelegate(delegate);
+}
+
+#endif // __APPLE__

--- a/src/plugins/menu/cocoa.mm
+++ b/src/plugins/menu/cocoa.mm
@@ -33,7 +33,7 @@ public:
       : m_refCount(1), m_interface(interface), m_menu(nullptr), m_item(nullptr),
         m_parent(nullptr), m_children(), m_caption(caption), m_modifier(""),
         m_checked(false), m_enabled(true), m_visible(true), m_radio(false),
-        m_radioGroup(true), m_delegate(nullptr), m_activated(false) {
+        m_activated(false), m_radioGroup(true), m_delegate(nullptr) {
     // create an empty menu stub
   }
 
@@ -154,7 +154,7 @@ public:
       m_item    = [NSMenuItem separatorItem];
       m_caption = caption;
       if (m_parent) {
-        [(m_parent->m_menu) remove:m_item];
+        [(m_parent->m_menu) removeItem:m_item];
         [(m_parent->m_menu) insertItem:m_item
                                atIndex:static_cast<NSInteger>(at)];
       }
@@ -165,7 +165,7 @@ public:
       m_caption = caption;
       ensureMenuItem();
       if (m_parent) {
-        [(m_parent->m_menu) remove:m_item];
+        [(m_parent->m_menu) removeItem:m_item];
         [(m_parent->m_menu) insertItem:m_item
                                atIndex:static_cast<NSInteger>(at)];
       }
@@ -307,7 +307,7 @@ private:
   size_t                              m_refCount;
   NativeMenuItem *                    m_interface;
   NSMenu *                            m_menu;
-  KrkrMenuItem *                      m_item;
+  NSMenuItem *                        m_item;
   _NativeMenuItem_Impl *              m_parent;
   std::vector<_NativeMenuItem_Impl *> m_children;
   std::string                         m_caption;

--- a/src/plugins/menu/common.h
+++ b/src/plugins/menu/common.h
@@ -42,8 +42,8 @@ public:
   void setChecked(bool flag);
   bool getChecked() const;
 
-  void               setKeyModifier(std::string const &modifier);
-  std::string const &getKeyModifier();
+  void               setKeyEquivalent(std::string const &key);
+  std::string const &getKeyEquivalent();
 
   void setEnabled(bool flag);
   bool getEnabled() const;

--- a/src/plugins/menu/common.h
+++ b/src/plugins/menu/common.h
@@ -20,6 +20,7 @@ class NativeMenuItem;
 class INativeMenuItemDelegate {
 public:
   virtual void handleClick(NativeMenuItem *sender);
+  virtual ~INativeMenuItemDelegate();
 };
 
 class NativeMenuItem {

--- a/src/plugins/menu/common.h
+++ b/src/plugins/menu/common.h
@@ -1,0 +1,70 @@
+/**
+ * @file     common.h
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    Cross-platform menu.dll implementation.
+ * @version  0.1
+ * @date     2020-08-09
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+class _NativeMenuItem_Impl;
+class NativeMenuItem;
+
+class INativeMenuItemDelegate {
+public:
+  virtual void handleClick(NativeMenuItem *sender);
+};
+
+class NativeMenuItem {
+public:
+  NativeMenuItem(std::string caption = "", void *nativeWindow = nullptr);
+  virtual ~NativeMenuItem();
+
+  void activate();
+  void addItem(NativeMenuItem *item);
+  void insert(NativeMenuItem *item, int at);
+  void retain();
+  bool release();
+  void popup(int flags, int x, int y);
+  void remove(NativeMenuItem *item);
+
+  void               setCaption(std::string const &caption);
+  std::string const &getCaption();
+
+  void setChecked(bool flag);
+  bool getChecked() const;
+
+  void               setKeyModifier(std::string const &modifier);
+  std::string const &getKeyModifier();
+
+  void setEnabled(bool flag);
+  bool getEnabled() const;
+
+  void setVisible(bool flag);
+  bool getVisible() const;
+
+  void setIndex(int index);
+  int  getIndex() const;
+
+  void setRadio(bool flag);
+  bool getRadio() const;
+
+  void setGroup(int group);
+  int  getGroup() const;
+
+  NativeMenuItem *              getRoot();
+  NativeMenuItem *              getParent();
+  std::vector<NativeMenuItem *> getChildren();
+
+  void setDelegate(INativeMenuItemDelegate *delegate);
+
+private:
+  _NativeMenuItem_Impl *m_impl;
+};

--- a/src/plugins/menu/common.h
+++ b/src/plugins/menu/common.h
@@ -19,8 +19,8 @@ class NativeMenuItem;
 
 class INativeMenuItemDelegate {
 public:
-  virtual void handleClick(NativeMenuItem *sender);
-  virtual ~INativeMenuItemDelegate();
+  virtual void handleClick(NativeMenuItem *sender) = 0;
+  virtual ~INativeMenuItemDelegate() {};
 };
 
 class NativeMenuItem {

--- a/src/plugins/menu/menu.cc
+++ b/src/plugins/menu/menu.cc
@@ -58,6 +58,26 @@ public:
       NativeMenuItem::setCaption(caption_);
     }
   }
+
+  tTJSVariant getKeyEquivalent() {
+    tjs_string output;
+    auto       key = NativeMenuItem::getKeyEquivalent();
+    TVPEncodeUTF8ToUTF16(output, key);
+    return ttstr(output);
+  }
+
+  void setKeyEquivalent(tTJSVariant key) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+
+    auto str = key.AsStringNoAddRef();
+
+    if (str) {
+      auto key_ = converter.to_bytes(
+          tjs_string(str->LongString ? str->LongString : str->ShortString,
+                     str->GetLength()));
+      NativeMenuItem::setKeyEquivalent(key_);
+    }
+  }
 };
 
 void PostRegistMenu() {
@@ -234,7 +254,7 @@ NCB_REGISTER_CLASS(MenuItemBase) {
   NCB_METHOD(popup);
 
   NCB_PROPERTY(caption, getCaption, setCaption);
-  // NCB_PROPERTY(shortcut, getKeyModifier, setKeyModifier);
+  NCB_PROPERTY(shortcut, getKeyEquivalent, setKeyEquivalent);
 
   NCB_PROPERTY(enabled, getEnabled, setEnabled);
   NCB_PROPERTY(visible, getVisible, setVisible);

--- a/src/plugins/menu/menu.cc
+++ b/src/plugins/menu/menu.cc
@@ -259,6 +259,7 @@ NCB_REGISTER_CLASS(MenuItemBase) {
   NCB_PROPERTY(enabled, getEnabled, setEnabled);
   NCB_PROPERTY(visible, getVisible, setVisible);
   NCB_PROPERTY(index, getIndex, setIndex);
+  NCB_PROPERTY(checked, getChecked, setChecked);
   NCB_PROPERTY(radio, getRadio, setRadio);
   NCB_PROPERTY(group, getGroup, setGroup);
 

--- a/src/plugins/menu/menu.cc
+++ b/src/plugins/menu/menu.cc
@@ -12,12 +12,12 @@
 #include "menu.h"
 #include "ncbind/ncbind.hpp"
 
+#ifdef MENUEX_IMPLEMENTED
+
 #include <codecvt>
 #include <locale>
 
 extern bool TVPEncodeUTF8ToUTF16(tjs_string &output, const std::string &source);
-// extern bool TVPEncodeUTF16ToUTF8(std::string &output, const tjs_string
-// &source);
 
 class MenuItemBase : public NativeMenuItem, INativeMenuItemDelegate {
 private:
@@ -286,3 +286,5 @@ NCB_REGISTER_CLASS(MenuItemBase) {
 };
 
 NCB_POST_REGIST_CALLBACK(PostRegistMenu);
+
+#endif

--- a/src/plugins/menu/menu.cc
+++ b/src/plugins/menu/menu.cc
@@ -1,0 +1,250 @@
+/**
+ * @file     menu.cc
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    Cross-platform menu.dll implementation.
+ * @version  0.1
+ * @date     2020-08-09
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ *
+ */
+
+#include "menu.h"
+#include "ncbind/ncbind.hpp"
+
+#include <codecvt>
+#include <locale>
+
+extern bool TVPEncodeUTF8ToUTF16(tjs_string &output, const std::string &source);
+// extern bool TVPEncodeUTF16ToUTF8(std::string &output, const tjs_string
+// &source);
+
+class MenuItemBase : public NativeMenuItem {
+public:
+  MenuItemBase() : NativeMenuItem() {}
+  virtual ~MenuItemBase() {}
+
+  void add(MenuItemBase *item) {
+    assert("menu item should not be null" && item != nullptr);
+    NativeMenuItem::addItem(item);
+  }
+
+  void insert(MenuItemBase *item, int at) {
+    assert("menu item should not be null" && item != nullptr);
+    NativeMenuItem::insert(item, at);
+  }
+
+  void remove(MenuItemBase *item) {
+    assert("menu item should not be null" && item != nullptr);
+    NativeMenuItem::remove(item);
+  }
+
+  tTJSVariant getCaption() {
+    tjs_string output;
+    auto       caption = NativeMenuItem::getCaption();
+    TVPEncodeUTF8ToUTF16(output, caption);
+    return ttstr(output);
+  }
+
+  void setCaption(tTJSVariant caption) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+
+    auto str = caption.AsStringNoAddRef();
+
+    if (str) {
+      auto caption_ = converter.to_bytes(
+          tjs_string(str->LongString ? str->LongString : str->ShortString,
+                     str->GetLength()));
+      NativeMenuItem::setCaption(caption_);
+    }
+  }
+};
+
+void PostRegistMenu() {
+  tTJSVariant var;
+  TVPExecuteScript(TJS_W(R"__TJS_SCRIPT___(
+/**
+ * @file     cocoaMenuGlue.tjs
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    Cross-platform menu.dll implementation.
+ * @version  0.1
+ * @date     2020-08-09
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ *
+ */
+
+class MenuListener {
+	function updateMenuItem(item: MenuItem) {}
+	function updateMenuList(parent: MenuItem ) {}
+	function selectMenuItem(item: MenuItem) {}
+};
+
+class MenuItem extends MenuItemBase {
+  var m_parent: Array;
+  var m_children: MenuItem;
+  var m_window: Window;
+  var m_listener: MenuListener;
+
+  function MenuItem(window: Window, caption: string="", listener: MenuListener=null) {
+    super.MenuItemBase();
+
+    m_children = new Array();
+    m_window = window;
+    m_listener = listener;
+
+    this.caption = caption;
+  }
+  
+  function finalize {
+		super.finalize(...);
+	}
+
+  function updateItem() {
+		if( m_listener != null ) {
+			m_listener.updateMenuItem( this );
+		}
+	}
+
+	function updateList() {
+		if( m_listener != null ) {
+			m_listener.updateMenuList( this );
+		}
+	}
+
+	function selectItem() {
+		if( m_listener != null ) {
+			listener.selectMenuItem( this );
+		}
+	}
+
+  function add(item: MenuItem) {
+		m_children.add(item);
+
+    item.m_parent = this;
+    super.add(item);
+
+		updateList();
+	}
+
+  function insert(index, item) {
+    // swap arguments
+		if (typeof index === "Object") {
+			if (typeof item !== "Object")
+        insert(item, index);
+			return;
+		}
+
+		m_children.remove(item);
+		m_children.insert(index, item);
+
+    item.m_parent = this;
+
+    super.insert(item, index);
+
+		updateList();
+	}
+
+	function remove(item: MenuItem) {
+		m_children.remove(item);
+		item.m_parent = null;
+		updateList();
+	}
+
+  property parent { getter{ return m_parent; } }
+
+	property children { getter{ return m_children; } }
+
+  property index {
+		setter(c) {
+			if (m_parent) {
+        m_parent.insert(c, this); 
+      }
+		}
+		getter {
+			return super.index;
+		}
+	}
+
+  property root {
+		getter {
+			var r = this;
+			while( r.m_parent != null ) {
+				r = r.m_parent;
+			}
+			return r;
+		}
+	}
+
+  function onClick() {
+		selectItem();
+	}
+
+	function dump() {
+		var mes: string = "";
+		var par: MenuItem = parent_;
+		while( par != null ) {
+			mes += "    ";
+			par = par.parent_;
+		}
+		if( caption_ == "-" ) {
+			mes += "-------------------------------";
+		} else {
+			mes += caption_;
+		}
+		Debug.message( mes );
+		var count:int = children_.count;
+		for( var i:int = 0; i < count; i++ ) {
+			children_[i].dump();
+		}
+	}
+}
+
+class _WindowMenuPropHook {
+    property menu {
+        getter {
+            if (typeof this.__menu === "undefined") {
+                this.__menu = new MenuItem(this);
+                
+                if (typeof this.__menu.activate !== "undefined") {
+                    // TODO: the activation should follow the status of the window
+                    this.__menu.activate();
+                }
+            }
+
+            return this.__menu;
+        }
+    }
+}
+
+var _hook = new _WindowMenuPropHook();
+&global.Window.menu = &_hook.menu;
+      )__TJS_SCRIPT___"),
+                   &var);
+}
+
+NCB_REGISTER_CLASS(MenuItemBase) {
+  Constructor();
+
+  NCB_METHOD(add);
+  NCB_METHOD(insert);
+  NCB_METHOD(remove);
+
+  NCB_METHOD(activate);
+  NCB_METHOD(popup);
+
+  NCB_PROPERTY(caption, getCaption, setCaption);
+  // NCB_PROPERTY(shortcut, getKeyModifier, setKeyModifier);
+
+  NCB_PROPERTY(enabled, getEnabled, setEnabled);
+  NCB_PROPERTY(visible, getVisible, setVisible);
+  NCB_PROPERTY(index, getIndex, setIndex);
+  NCB_PROPERTY(radio, getRadio, setRadio);
+  NCB_PROPERTY(group, getGroup, setGroup);
+
+  // NCB_PROPERTY_RO(root, getRoot);
+  // NCB_PROPERTY_RO(parent, getParent);
+  // NCB_PROPERTY_RO(children, getChildren);
+};
+
+NCB_POST_REGIST_CALLBACK(PostRegistMenu);

--- a/src/plugins/menu/menu.cc
+++ b/src/plugins/menu/menu.cc
@@ -109,9 +109,9 @@ void PostRegistMenu() {
  */
 
 class MenuListener {
-	function updateMenuItem(item: MenuItem) {}
-	function updateMenuList(parent: MenuItem ) {}
-	function selectMenuItem(item: MenuItem) {}
+  function updateMenuItem(item: MenuItem) {}
+  function updateMenuList(parent: MenuItem ) {}
+  function selectMenuItem(item: MenuItem) {}
 };
 
 class MenuItem extends MenuItemBase {
@@ -132,107 +132,107 @@ class MenuItem extends MenuItemBase {
   }
   
   function finalize {
-		super.finalize(...);
-	}
+    super.finalize(...);
+  }
 
   function updateItem() {
-		if( m_listener != null ) {
-			m_listener.updateMenuItem( this );
-		}
-	}
+    if( m_listener != null ) {
+      m_listener.updateMenuItem( this );
+    }
+  }
 
-	function updateList() {
-		if( m_listener != null ) {
-			m_listener.updateMenuList( this );
-		}
-	}
+  function updateList() {
+    if( m_listener != null ) {
+      m_listener.updateMenuList( this );
+    }
+  }
 
-	function selectItem() {
-		if( m_listener != null ) {
-			listener.selectMenuItem( this );
-		}
-	}
+  function selectItem() {
+    if( m_listener != null ) {
+      listener.selectMenuItem( this );
+    }
+  }
 
   function add(item: MenuItem) {
-		m_children.add(item);
+    m_children.add(item);
 
     item.m_parent = this;
     super.add(item);
 
-		updateList();
-	}
+    updateList();
+  }
 
   function insert(index, item) {
     // swap arguments
-		if (typeof index === "Object") {
-			if (typeof item !== "Object")
+    if (typeof index === "Object") {
+      if (typeof item !== "Object")
         insert(item, index);
-			return;
-		}
+      return;
+    }
 
-		m_children.remove(item);
-		m_children.insert(index, item);
+    m_children.remove(item);
+    m_children.insert(index, item);
 
     item.m_parent = this;
 
     super.insert(item, index);
 
-		updateList();
-	}
+    updateList();
+  }
 
-	function remove(item: MenuItem) {
-		m_children.remove(item);
-		item.m_parent = null;
-		updateList();
-	}
+  function remove(item: MenuItem) {
+    m_children.remove(item);
+    item.m_parent = null;
+    updateList();
+  }
 
   property parent { getter{ return m_parent; } }
 
-	property children { getter{ return m_children; } }
+  property children { getter{ return m_children; } }
 
   property index {
-		setter(c) {
-			if (m_parent) {
+    setter(c) {
+      if (m_parent) {
         m_parent.insert(c, this); 
       }
-		}
-		getter {
-			return super.index;
-		}
-	}
+    }
+    getter {
+      return super.index;
+    }
+  }
 
   property root {
-		getter {
-			var r = this;
-			while( r.m_parent != null ) {
-				r = r.m_parent;
-			}
-			return r;
-		}
-	}
+    getter {
+      var r = this;
+      while( r.m_parent != null ) {
+        r = r.m_parent;
+      }
+      return r;
+    }
+  }
 
   function onClick() {
-		selectItem();
-	}
+    selectItem();
+  }
 
-	function dump() {
-		var mes: string = "";
-		var par: MenuItem = parent_;
-		while( par != null ) {
-			mes += "    ";
-			par = par.parent_;
-		}
-		if( caption_ == "-" ) {
-			mes += "-------------------------------";
-		} else {
-			mes += caption_;
-		}
-		Debug.message( mes );
-		var count:int = children_.count;
-		for( var i:int = 0; i < count; i++ ) {
-			children_[i].dump();
-		}
-	}
+  function dump() {
+    var mes: string = "";
+    var par: MenuItem = parent_;
+    while( par != null ) {
+      mes += "    ";
+      par = par.parent_;
+    }
+    if( caption_ == "-" ) {
+      mes += "-------------------------------";
+    } else {
+      mes += caption_;
+    }
+    Debug.message( mes );
+    var count:int = children_.count;
+    for( var i:int = 0; i < count; i++ ) {
+      children_[i].dump();
+    }
+  }
 }
 
 class _WindowMenuPropHook {

--- a/src/plugins/menu/menu.h
+++ b/src/plugins/menu/menu.h
@@ -14,3 +14,7 @@
 #include "tp_stub.h"
 #include "ObjectList.h"
 #include "common.h"
+
+#ifdef __APPLE__
+#define MENUEX_IMPLEMENTED
+#endif

--- a/src/plugins/menu/menu.h
+++ b/src/plugins/menu/menu.h
@@ -1,0 +1,16 @@
+/**
+ * @file     menuitem.h
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    Cross-platform menu.dll implementation.
+ * @version  0.1
+ * @date     2020-08-09
+ *
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "tp_stub.h"
+#include "ObjectList.h"
+#include "common.h"

--- a/src/plugins/menu/win32.cc
+++ b/src/plugins/menu/win32.cc
@@ -1,0 +1,10 @@
+/**
+ * @file     win32.cc
+ * @author   Hikaru Terazono <3c1u@vulpesgames.tokyo>
+ * @brief    Windows-specific menu.dll implementation.
+ * @version  0.1
+ * @date     2020-08-09
+ * 
+ * @copyright Copyright (c) 2020 Hikaru Terazono (3c1u). All rights reserved.
+ * 
+ */


### PR DESCRIPTION
## 実装状況

<img width="573" alt="image" src="https://user-images.githubusercontent.com/298748/89741764-f498e380-dace-11ea-89cf-2bc79434537f.png">

- [X] メニュー作成
- [x] チェックボックス・ラジオボタン
- [x] ショートカットキー
- [x] クリックイベントの送出
- macOS固有
  - [ ] Applicationメニュー
  - [ ] "Window"メニュー
  - [X] `'&'`の除去

## 注意

ネイティブで`MenuItemBase`を実装した後，TJSで`MenuItem`クラスに継承してます．ncbindでつくったクラスのTJSインスタンスを取得する方法がわからずこんなことになっているので，もう少し良い方法があったらお教えください．

ApplicationメニューとWindowメニューは小細工が必要ですが，実用上はあまりいらなそうでなので...．
